### PR TITLE
test: cleanup and rewrite tests

### DIFF
--- a/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.spec.ts
+++ b/libs/ngx-mime/src/lib/core/navigation/content-search-navigation-service/content-search-navigation.service.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { Spy, provideAutoSpy } from 'jest-auto-spies';
-import { IiifManifestServiceStub } from '../../../test/iiif-manifest-service-stub';
 import { testManifest } from '../../../test/testManifest';
 import { CanvasService } from '../../canvas-service/canvas-service';
 import { IiifContentSearchService } from '../../iiif-content-search-service/iiif-content-search.service';
@@ -11,10 +10,10 @@ import { SearchResult } from '../../models/search-result';
 import { ContentSearchNavigationService } from './content-search-navigation.service';
 
 describe('ContentSearchNavigationService', () => {
-  let iiifContentSearchServiceSpy: Spy<IiifContentSearchService>;
-  let iiifManifestServiceStub: IiifManifestServiceStub;
   let contentSearchNavigationService: ContentSearchNavigationService;
   let canvasServiceSpy: Spy<CanvasService>;
+  let iiifContentSearchServiceSpy: Spy<IiifContentSearchService>;
+  let iiifManifestServiceSpy: Spy<IiifManifestService>;
   let defaultSearchResult = createSearchResult();
 
   beforeEach(() => {
@@ -24,7 +23,9 @@ describe('ContentSearchNavigationService', () => {
       providers: [
         ContentSearchNavigationService,
         provideAutoSpy(CanvasService),
-        { provide: IiifManifestService, useClass: IiifManifestServiceStub },
+        provideAutoSpy(IiifManifestService, {
+          observablePropsToSpyOn: ['currentManifest'],
+        }),
         provideAutoSpy(IiifContentSearchService, {
           observablePropsToSpyOn: ['onChange'],
         }),
@@ -34,8 +35,10 @@ describe('ContentSearchNavigationService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    iiifManifestServiceStub = TestBed.inject<any>(IiifManifestService);
-    iiifManifestServiceStub._currentManifest.next(testManifest);
+    iiifManifestServiceSpy = TestBed.inject(
+      IiifManifestService,
+    ) as Spy<IiifManifestService>;
+    iiifManifestServiceSpy.currentManifest.nextWith(testManifest);
     iiifContentSearchServiceSpy = TestBed.inject<any>(IiifContentSearchService);
     iiifContentSearchServiceSpy.onChange.nextWith(defaultSearchResult);
     canvasServiceSpy = <any>TestBed.inject(CanvasService);

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.html
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.html
@@ -19,7 +19,7 @@
     [innerHTML]="intl.currentHitLabel(currentHit + 1, searchResult.size())"
   ></div>
   <div class="navigation-buttons">
-    <ng-container *ngIf="invert">
+    <ng-container *ngIf="!invert">
       <button
         data-testid="footerNavigatePreviousHitButton"
         mat-icon-button
@@ -43,7 +43,7 @@
         <mat-icon>navigate_next</mat-icon>
       </button>
     </ng-container>
-    <ng-container *ngIf="!invert">
+    <ng-container *ngIf="invert">
       <button
         data-testid="footerNavigateNextHitButton"
         mat-icon-button

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.spec.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.spec.ts
@@ -15,14 +15,13 @@ import { SearchResult } from '../../../core/models/search-result';
 import { ContentSearchNavigationService } from '../../../core/navigation/content-search-navigation-service/content-search-navigation.service';
 import { ViewerLayoutService } from '../../../core/viewer-layout-service/viewer-layout-service';
 import { SharedModule } from '../../../shared/shared.module';
-import { IiifContentSearchServiceStub } from '../../../test/iiif-content-search-service-stub';
 import { IiifManifestServiceStub } from '../../../test/iiif-manifest-service-stub';
 import { ContentSearchNavigatorComponent } from './content-search-navigator.component';
 
 describe('ContentSearchNavigatorComponent', () => {
   let component: ContentSearchNavigatorComponent;
   let fixture: ComponentFixture<ContentSearchNavigatorComponent>;
-  let iiifContentSearchService: IiifContentSearchServiceStub;
+  let iiifContentSearchServiceSpy: Spy<IiifContentSearchService>;
   let canvasServiceSpy: Spy<CanvasService>;
   let contentSearchNavigationServiceSpy: Spy<ContentSearchNavigationService>;
   let viewerLayoutServiceSpy: Spy<ViewerLayoutService>;
@@ -38,10 +37,9 @@ describe('ContentSearchNavigatorComponent', () => {
       declarations: [ContentSearchNavigatorComponent],
       providers: [
         MimeViewerIntl,
-        {
-          provide: IiifContentSearchService,
-          useClass: IiifContentSearchServiceStub,
-        },
+        provideAutoSpy(IiifContentSearchService, {
+          observablePropsToSpyOn: ['onChange'],
+        }),
         provideAutoSpy(ContentSearchNavigationService, {
           observablePropsToSpyOn: ['currentHitCounter'],
         }),
@@ -59,7 +57,9 @@ describe('ContentSearchNavigatorComponent', () => {
   beforeEach(async () => {
     fixture = TestBed.createComponent(ContentSearchNavigatorComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
-    iiifContentSearchService = TestBed.inject<any>(IiifContentSearchService);
+    iiifContentSearchServiceSpy = TestBed.inject(
+      IiifContentSearchService,
+    ) as Spy<IiifContentSearchService>;
     intl = TestBed.inject(MimeViewerIntl);
     contentSearchNavigationServiceSpy = TestBed.inject(
       ContentSearchNavigationService,
@@ -71,7 +71,7 @@ describe('ContentSearchNavigatorComponent', () => {
 
     component = fixture.componentInstance;
     component.searchResult = createDefaultData();
-    iiifContentSearchService._currentSearchResult.next(component.searchResult);
+    iiifContentSearchServiceSpy.onChange.nextWith(component.searchResult);
     fixture.detectChanges();
 
     nextButton = await loader.getHarness(

--- a/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.ts
+++ b/libs/ngx-mime/src/lib/viewer/viewer-footer/content-search-navigator/content-search-navigator.component.ts
@@ -41,7 +41,7 @@ export class ContentSearchNavigatorComponent
     private canvasService: CanvasService,
     private iiifContentSearchService: IiifContentSearchService,
     private contentSearchNavigationService: ContentSearchNavigationService,
-    private iiifManifestService: IiifManifestService
+    private iiifManifestService: IiifManifestService,
   ) {}
 
   ngOnInit() {
@@ -50,21 +50,22 @@ export class ContentSearchNavigatorComponent
       this.contentSearchNavigationService.currentHitCounter.subscribe((n) => {
         this.currentHit = n;
         this.updateHitStatus();
-      })
+        this.changeDetectorRef.detectChanges();
+      }),
     );
     this.subscriptions.add(
       this.iiifManifestService.currentManifest.subscribe(
         (manifest: Manifest | null) => {
           if (manifest) {
-            this.invert = manifest.viewingDirection === ViewingDirection.LTR;
+            this.invert = manifest.viewingDirection !== ViewingDirection.LTR;
             this.changeDetectorRef.detectChanges();
           }
-        }
-      )
+        },
+      ),
     );
 
     this.subscriptions.add(
-      this.intl.changes.subscribe(() => this.changeDetectorRef.markForCheck())
+      this.intl.changes.subscribe(() => this.changeDetectorRef.markForCheck()),
     );
 
     this.subscriptions.add(
@@ -74,8 +75,8 @@ export class ContentSearchNavigatorComponent
           this.isHitOnActiveCanvasGroup =
             this.contentSearchNavigationService.getHitOnActiveCanvasGroup();
           this.changeDetectorRef.detectChanges();
-        }
-      )
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
- Fixed an incorrectly inverted variable.
- Moved unnecessary tests from content-search-navigator specs to content-search-navigation-service specs.
- Cleaned up existing tests and added new ones.